### PR TITLE
Use non-proprietary icon for reminder

### DIFF
--- a/examples/material_expansionpanel_example/lib/material_expansionpanel_example.html
+++ b/examples/material_expansionpanel_example/lib/material_expansionpanel_example.html
@@ -44,7 +44,7 @@
 
     <material-expansionpanel wide>
       <div name>
-        <material-icon icon="reminder" class="reminder" size="medium"></material-icon>
+        <material-icon icon="notifications" class="reminder" size="medium"></material-icon>
         Reminder
       </div>
       <div value>


### PR DESCRIPTION
reminder icon is not available in open source material icons, so it does not display in https://dart-lang.github.io/angular_components/#/material_expansion_panel 